### PR TITLE
Fix OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,9 @@
           		  io.vertx.lang.rxjava;resolution:=optional, \
           		  io.vertx.rx.java;resolution:=optional, \
           		  io.vertx.rxjava.core;resolution:=optional, \
+          		  io.vertx.codegen.annotations;resolution:=optional, \
+          		  !io.vertx.ext.jdbc, \
+          		  !io.vertx.ext.sql, \
                   *
                 -exportcontents: !*impl, !examples, *
           ]]></bnd>


### PR DESCRIPTION
This change fixes the generated OSGi manifest entries by disabling
imports of dependencies used in the examples and marking the resolution
of the `vertx-codegen` annotations as optional.