### PR TITLE
Do not add http headers to HttpServerResponses that are already closed or ended

### DIFF
--- a/src/main/java/io/vertx/ext/healthchecks/impl/HealthCheckHandlerImpl.java
+++ b/src/main/java/io/vertx/ext/healthchecks/impl/HealthCheckHandlerImpl.java
@@ -101,7 +101,7 @@ public class HealthCheckHandlerImpl implements HealthCheckHandler {
   private Handler<AsyncResult<JsonObject>> healthReportHandler(RoutingContext rc) {
     return json -> {
       HttpServerResponse response = rc.response()
-                                      .putHeader(HttpHeaders.CONTENT_TYPE, "application/json;charset=UTF-8");
+        .putHeader(HttpHeaders.CONTENT_TYPE, "application/json;charset=UTF-8");
       if (json.failed()) {
         if (json.cause().getMessage().toLowerCase().contains("not found")) {
           response.setStatusCode(404);

--- a/src/main/java/io/vertx/ext/healthchecks/impl/HealthCheckHandlerImpl.java
+++ b/src/main/java/io/vertx/ext/healthchecks/impl/HealthCheckHandlerImpl.java
@@ -87,11 +87,9 @@ public class HealthCheckHandlerImpl implements HealthCheckHandler {
       authProvider.authenticate(authData, ar -> {
         if (ar.failed()) {
           rc.response().setStatusCode(403).end();
-        } else if (rc.response().closed() || rc.response().ended()) {
-          rc.fail(500);
-        } else {
+        } else if (!rc.response().closed() && !rc.response().ended()) {
           healthChecks.invoke(id, healthReportHandler(rc));
-        }
+        } 
       });
     } else if (!rc.response().closed() && !rc.response().ended()) {
       healthChecks.invoke(id, healthReportHandler(rc));


### PR DESCRIPTION
```java
private Handler<AsyncResult<JsonObject>> healthReportHandler(RoutingContext rc) {
    return json -> {
      HttpServerResponse response = 
              rc.response()
              // calling putHeader() here, if response is closed will raise an exception
              .putHeader(HttpHeaders.CONTENT_TYPE, "application/json;charset=UTF-8");
   ...
```

If an HttpServerResponse is already ended or has been closed, calling .putHeader() or other methods on it does result in an "java.lang.IllegalStateException: Response is closed ".

Therefore, it should be checked if the response is writable, before adding headers or setting statuscodes.