### PR TITLE
Health check collector

### DIFF
--- a/src/main/java/examples/HealthCheckExamples.java
+++ b/src/main/java/examples/HealthCheckExamples.java
@@ -5,6 +5,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthChecks;
 import io.vertx.ext.healthchecks.Status;
+import io.vertx.ext.healthchecks.collector.HealthCheckCollector;
+import io.vertx.ext.healthchecks.collector.HealthCheckContributor;
+import io.vertx.ext.healthchecks.collector.HealthProcedures;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -46,6 +49,24 @@ public class HealthCheckExamples {
 
     healthChecks.register("my-second-procedure-name", promise -> {
       promise.complete(Status.KO(new JsonObject().put("load", 99)));
+    });
+  }
+
+  public void example5(Vertx vertx) {
+    // health check collector initialized in verticle hosting http client
+    HealthCheckCollector livenessHealthCheck = HealthCheckCollector.create(vertx, "liveness");
+
+    // create health check contributor in any verticle to register procedure for the health check
+    HealthCheckContributor livenessCheckContributorVerticle1 = HealthCheckContributor.create(vertx, "liveness");
+    livenessCheckContributorVerticle1.register("my-procedure-name1", handler -> {
+      // add health check logic here
+      handler.complete(Status.OK());
+    });
+
+    HealthCheckContributor livenessCheckContributorVerticle2 = HealthCheckContributor.create(vertx, "liveness");
+    livenessCheckContributorVerticle2.register("my-procedure-name2", handler -> {
+      // add health check logic here
+      handler.complete(Status.OK());
     });
   }
 

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckCollector.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckCollector.java
@@ -1,0 +1,128 @@
+package io.vertx.ext.healthchecks.collector;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.ext.healthchecks.Status;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HealthCheckCollector {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckCollector.class);
+
+  private static final String DEFAULT_HEALTH_CHECK_NAME = "default";
+  private static final int DEFAULT_TIMEOUT_MS = 2000;
+
+  private final Set<String> registeredHealthChecks = new HashSet<>();
+  private final HealthChecks healthChecks;
+  private final EventBus eventBus;
+  private final String identifier;
+
+  public static HealthCheckCollector create(Vertx vertx, String identifier) {
+    return create(HealthChecks.create(vertx), vertx.eventBus(), identifier);
+  }
+
+  public static HealthCheckCollector create(
+      HealthChecks healthChecks, EventBus eventBus, String identifier) {
+    return new HealthCheckCollector(healthChecks, eventBus, identifier);
+  }
+
+  private HealthCheckCollector(HealthChecks healthChecks, EventBus eventBus, String identifier) {
+    this.healthChecks = healthChecks;
+    this.eventBus = eventBus;
+    this.identifier = identifier;
+    createDefaultHealthCheck();
+    setupEventBusCommunication();
+  }
+
+  public void register(String name, Handler<Promise<Status>> procedure) {
+    register(name, DEFAULT_TIMEOUT_MS, procedure);
+  }
+
+  public void register(String name, long timeout, Handler<Promise<Status>> procedure) {
+    if (registeredHealthChecks.contains(name)) {
+      LOGGER.warn("Already registered health check '" + name + "'. Ignoring...");
+      return;
+    }
+    unregister(DEFAULT_HEALTH_CHECK_NAME);
+
+    healthChecks.register(name, timeout, procedure);
+    registeredHealthChecks.add(name);
+  }
+
+  public HealthChecks unregister(String name) {
+    registeredHealthChecks.remove(name);
+    return healthChecks.unregister(name);
+  }
+
+  public void unregisterAll() {
+    registeredHealthChecks.forEach(this::unregister);
+  }
+
+  private void createDefaultHealthCheck() {
+    register(DEFAULT_HEALTH_CHECK_NAME, p -> p.complete(Status.OK()));
+  }
+
+  private void setupEventBusCommunication() {
+    setupHandlingOfHealthCheckRegistrations();
+    setupHandlingOfHealthCheckDeregistrations();
+  }
+
+  private void setupHandlingOfHealthCheckRegistrations() {
+    eventBus.<JsonObject>consumer(
+        HealthEventBusAddresses.forHealthCheckContributorRegistration(identifier),
+        msg -> {
+          HealthCheckRegistrationMessage registrationMsg =
+              msg.body().mapTo(HealthCheckRegistrationMessage.class);
+
+          // check if already registered
+          if (registeredHealthChecks.contains(registrationMsg.getHealthCheckName())) {
+            LOGGER.warn(
+                "Already registered health check '" + registrationMsg.getHealthCheckName() + " '. Ignoring contributor...");
+            return;
+          }
+
+          // register health check
+          register(
+              registrationMsg.getHealthCheckName(),
+              DEFAULT_TIMEOUT_MS,
+              promise -> {
+                eventBus
+                    .<JsonObject>request(
+                        registrationMsg.getHealthCheckName(),
+                        "ping",
+                        new DeliveryOptions().setSendTimeout(DEFAULT_TIMEOUT_MS))
+                    .onComplete(
+                        resp -> {
+                          var status = new Status(resp.body());
+                          promise.complete(status);
+                        },
+                        promise::fail);
+              });
+
+          // reply to contributor
+          msg.reply("ok");
+          LOGGER.debug(
+              "New health check registered for " + identifier + ": " + registrationMsg.getHealthCheckName());
+        });
+  }
+
+  private void setupHandlingOfHealthCheckDeregistrations() {
+    eventBus.<JsonObject>consumer(
+        HealthEventBusAddresses.forHealthCheckContributorDeregistration(identifier),
+        msg -> {
+          HealthCheckDeregistrationMessage deregistrationMsg =
+              msg.body().mapTo(HealthCheckDeregistrationMessage.class);
+          unregister(deregistrationMsg.getHealthCheckName());
+          LOGGER.debug("New health deregistered for " + identifier + ": " + msg);
+          msg.reply("ok");
+        });
+  }
+}

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckContributor.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckContributor.java
@@ -1,0 +1,129 @@
+package io.vertx.ext.healthchecks.collector;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.Status;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+public class HealthCheckContributor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckContributor.class);
+
+  private static final int REGISTRATION_RETRY_DELAY = 100;
+  private static final int REGISTRATION_RETRY_COUNT = 50;
+  private static final int DEFAULT_TIMEOUT_MS = 2000;
+
+  private final HashMap<String, Integer> registerRetryCounters = new HashMap<>();
+  private final Set<String> healthChecks = new HashSet<>();
+  private final Vertx vertx;
+  private final String healthCheckCollectorIdentifier;
+
+  public static HealthCheckContributor create(Vertx vertx, String healthCheckCollectorIdentifier) {
+    return new HealthCheckContributor(vertx, healthCheckCollectorIdentifier);
+  }
+
+  private HealthCheckContributor(Vertx vertx, String healthCheckCollectorIdentifier) {
+    this.vertx = vertx;
+    this.healthCheckCollectorIdentifier = healthCheckCollectorIdentifier;
+  }
+
+  public void register(String healthCheckName, Handler<Promise<Status>> procedure) {
+    register(healthCheckName, DEFAULT_TIMEOUT_MS, procedure);
+  }
+
+  public void register(String healthCheckName, int timeoutMs, Handler<Promise<Status>> procedure) {
+    // setup health check
+    var myHealthCheckAddress =
+        HealthEventBusAddresses.forHealthCheck(healthCheckCollectorIdentifier, healthCheckName);
+    registerHealthCheck(myHealthCheckAddress, timeoutMs, procedure);
+
+    // register at collector
+    var registerAddress =
+        HealthEventBusAddresses.forHealthCheckContributorRegistration(
+            healthCheckCollectorIdentifier);
+    var registerMsg = new HealthCheckRegistrationMessage(healthCheckName, myHealthCheckAddress);
+    registerHealthCheckAtCollector(registerAddress, registerMsg);
+  }
+
+  private void registerHealthCheck(
+      String myHealthCheckAddress, int timeoutMs, Handler<Promise<Status>> procedure) {
+    vertx
+        .eventBus()
+        .consumer(
+            myHealthCheckAddress,
+            msg -> {
+              Future<String> timeoutFuture =
+                  vertx
+                      .timer(timeoutMs)
+                      .compose(
+                          v ->
+                              Future.failedFuture(
+                                  new TimeoutException(
+                                      "Health check timed out after " + timeoutMs + "ms")));
+
+              Promise<Status> timeCheckPromise = Promise.promise();
+              Future.any(timeCheckPromise.future(), timeoutFuture)
+                  .map(HealthCheckContributor::extractAnyResult)
+                  .onComplete(
+                      status -> msg.reply(status.toJson()), err -> msg.fail(500, err.getMessage()));
+              procedure.handle(timeCheckPromise);
+            });
+  }
+
+  private void registerHealthCheckAtCollector(
+      String address, HealthCheckRegistrationMessage registerMsg) {
+    vertx
+      .eventBus()
+      .request(address, JsonObject.mapFrom(registerMsg))
+      .onSuccess(msg -> {
+        healthChecks.add(registerMsg.getHealthCheckName());
+        LOGGER.debug("Health check registered at " + healthCheckCollectorIdentifier + ": " + registerMsg.getHealthCheckName());
+      })
+      .onFailure(err -> {
+        // retry logic
+        int retries = registerRetryCounters.getOrDefault(registerMsg.getHealthCheckName(), 0);
+        if (retries <= REGISTRATION_RETRY_COUNT) {
+          retries++;
+          registerRetryCounters.put(registerMsg.getHealthCheckName(), retries);
+          vertx.setTimer(
+            REGISTRATION_RETRY_DELAY,
+            ignored -> registerHealthCheckAtCollector(address, registerMsg));
+        }
+      });
+  }
+
+  public void unregister(String healthCheckName) {
+    var deregisterMsg = new HealthCheckDeregistrationMessage(healthCheckName);
+    var address = HealthEventBusAddresses.forHealthCheckContributorDeregistration(healthCheckCollectorIdentifier);
+    vertx
+        .eventBus()
+        .request(address, JsonObject.mapFrom(deregisterMsg))
+        .onSuccess(msg -> {
+          healthChecks.remove(healthCheckName);
+          LOGGER.debug("Health check deregistered at " + healthCheckCollectorIdentifier + ": " + healthCheckName);
+        });
+  }
+
+  public void unregisterAll() {
+    healthChecks.forEach(this::unregister);
+  }
+
+  private static Status extractAnyResult(CompositeFuture compositeFuture) {
+    for (int i = 0; i < compositeFuture.size(); i++) {
+      Status result = compositeFuture.resultAt(i);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckDeregistrationMessage.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckDeregistrationMessage.java
@@ -1,0 +1,29 @@
+package io.vertx.ext.healthchecks.collector;
+
+import java.util.Objects;
+
+class HealthCheckDeregistrationMessage {
+
+  private final String healthCheckName;
+
+  HealthCheckDeregistrationMessage(String healthCheckName) {
+    this.healthCheckName = healthCheckName;
+  }
+
+  public String getHealthCheckName() {
+    return healthCheckName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    HealthCheckDeregistrationMessage that = (HealthCheckDeregistrationMessage) o;
+    return Objects.equals(healthCheckName, that.healthCheckName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(healthCheckName);
+  }
+
+}

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckRegistrationMessage.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthCheckRegistrationMessage.java
@@ -1,0 +1,35 @@
+package io.vertx.ext.healthchecks.collector;
+
+import java.util.Objects;
+
+class HealthCheckRegistrationMessage {
+
+  private final String healthCheckName;
+  private final String healthCheckAddress;
+
+  HealthCheckRegistrationMessage(String healthCheckName, String healthCheckAddress) {
+    this.healthCheckName = healthCheckName;
+    this.healthCheckAddress = healthCheckAddress;
+  }
+
+  public String getHealthCheckName() {
+    return healthCheckName;
+  }
+
+  public String getHealthCheckAddress() {
+    return healthCheckAddress;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    HealthCheckRegistrationMessage that = (HealthCheckRegistrationMessage) o;
+    return Objects.equals(healthCheckName, that.healthCheckName) && Objects.equals(healthCheckAddress, that.healthCheckAddress);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(healthCheckName, healthCheckAddress);
+  }
+
+}

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthEventBusAddresses.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthEventBusAddresses.java
@@ -1,0 +1,18 @@
+package io.vertx.ext.healthchecks.collector;
+
+class HealthEventBusAddresses {
+
+  private HealthEventBusAddresses() {}
+
+  static String forHealthCheckContributorRegistration(String identifier) {
+    return "health.register." + identifier;
+  }
+
+  static String forHealthCheckContributorDeregistration(String identifier) {
+    return "health.unregister." + identifier;
+  }
+
+  static String forHealthCheck(String identifier, String healthCheckName) {
+    return "health.procedure." + identifier + "." + healthCheckName;
+  }
+}

--- a/src/main/java/io/vertx/ext/healthchecks/collector/HealthProcedures.java
+++ b/src/main/java/io/vertx/ext/healthchecks/collector/HealthProcedures.java
@@ -1,0 +1,21 @@
+package io.vertx.ext.healthchecks.collector;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.ext.healthchecks.Status;
+
+public interface HealthProcedures {
+
+  static Handler<Promise<Status>> checkPromiseSucceeded(Promise<?> promiseToCheck) {
+    final var futureToCheck = promiseToCheck.future();
+    return promise -> {
+      var status = futureToCheck.isComplete() ? Status.OK() : Status.KO();
+      promise.complete(status);
+    };
+  }
+
+  static Handler<Promise<Status>> checkEventLoopFunctional() {
+    return promise -> promise.complete(Status.OK());
+  }
+
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module io.vertx.healthcheck {
   requires static io.vertx.codegen.json;
 
   requires io.vertx.core;
+  requires io.vertx.core.logging;
 
   exports io.vertx.ext.healthchecks;
   exports io.vertx.ext.healthchecks.impl to io.vertx.healthcheck.tests;


### PR DESCRIPTION
Motivation:

While implementing liveness and readiness probes, I encountered a decoupling issue: health checks had to be initialized inside the HTTP server verticle to expose them via the REST API, but the actual components contributing to these checks are distributed across various verticles throughout the service.

To resolve this architectural mismatch, this PR introduces a mechanism to announce and collect health check statuses asynchronously via the Vert.x event bus. This decouples the HTTP infrastructure from the individual component logic.

Conformance:

- Accepted the ECA
- Adhered to the code style guidelines to the best of my knowledge.
